### PR TITLE
chore: Removing unsupported versions of php.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "~5.6|~7.0|^8.0|^8.1"
+        "php": "~7.4|^8.0|^8.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~9.5",


### PR DESCRIPTION
I have removed support for version 5.6 and 7.0 of php as the code was already ahead of these versions. Support starts now from php 7.4.